### PR TITLE
Add tests for sliding text window

### DIFF
--- a/SlothCodeAnalysis.Tests/SlidingTextWindowTests.cs
+++ b/SlothCodeAnalysis.Tests/SlidingTextWindowTests.cs
@@ -13,28 +13,133 @@ namespace SlothCodeAnalysis.Tests
     class SlidingTextWindowTests
     {
         [Test]
-        public void Test1()
+        public void Text_WithSlidingTextWindowCreatedWithSetText_ReturnsText()
         {
-            // Arrange
             var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
             var slidingTextWindow = new SlidingTextWindow(sourceText);
 
-            // Act
-            int i = 0;
-            var nextChar = slidingTextWindow.NextChar();
-            while (nextChar != SlidingTextWindow.InvalidCharacter)
-            {
-                i++;
-                if (i == 10)
-                {
-                    slidingTextWindow.Reset(10);
-                }
+            Assert.AreEqual(sourceText, slidingTextWindow.Text);
+        }
 
-                slidingTextWindow.AdvanceChar();
-                nextChar = slidingTextWindow.NextChar();
-            }
+        [Test]
+        public void Position_WithNewSlidingTextWindow_IsZero()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
 
-            // Assert
+            Assert.AreEqual(0, slidingTextWindow.Position);
+        }
+
+        [Test]
+        public void Offset_WithNewSlidingTextWindow_IsZero()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            Assert.AreEqual(0, slidingTextWindow.Offset);
+        }
+
+        [Test]
+        public void AdvanceChar_OnNewSlidingTextWindow_ChangesOffsetTo1()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            slidingTextWindow.AdvanceChar();
+
+            Assert.AreEqual(1, slidingTextWindow.Offset);
+        }
+
+        [Test]
+        public void AdvanceCharBy5_OnNewSlidingTextWindow_ChangesOffsetTo5()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            slidingTextWindow.AdvanceChar(5);
+
+            Assert.AreEqual(5, slidingTextWindow.Offset);
+        }
+
+        [Test]
+        public void PeekChar_WithOffsetLessThanDefaultWindowLength_ReturnsCharacter()
+        {
+            var text = "abcdefghijklmnopqrstuvwyx0123456789";
+            var sourceText = SourceText.From(text);
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            var peekedChar = slidingTextWindow.PeekChar();
+
+            Assert.AreEqual(text[0], peekedChar);
+        }
+
+        [Test]
+        public void PeekChar_WithOffsetMoreThanDefaultWindowLength_ReturnsCharacter()
+        {
+            var text = "abcdefghijklmnopqrstuvwyx0123456789";
+            var sourceText = SourceText.From(text);
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            slidingTextWindow.AdvanceChar(30);
+
+            var peekedChar = slidingTextWindow.PeekChar();
+
+            Assert.AreEqual(text[30], peekedChar);
+        }
+
+        [Test]
+        public void NextChar_WithNoText_ReturnsInvalidCharacter()
+        {
+            var slidingTextWindow = new SlidingTextWindow(SourceText.From(""));
+
+            Assert.AreEqual(SlidingTextWindow.InvalidCharacter, slidingTextWindow.NextChar());
+        }
+
+        [Test]
+        public void NextChar_WithNoText_DoesNotChangePosition()
+        {
+            var slidingTextWindow = new SlidingTextWindow(SourceText.From(""));
+
+            slidingTextWindow.NextChar();
+
+            Assert.AreEqual(0, slidingTextWindow.Position);
+        }
+
+        [Test]
+        public void NextChar_WithValidCharacter_IncrementsPosition()
+        {
+            var slidingTextWindow = new SlidingTextWindow(SourceText.From("A"));
+
+            slidingTextWindow.NextChar();
+
+            Assert.AreEqual(1, slidingTextWindow.Position);
+        }
+
+        [Test]
+        public void Reset_WithPositionInWindow_SetOffsetBasedOnStartOfWindow()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            // Setup a non zero basis
+            slidingTextWindow.Reset(25);
+
+            // Real test
+            slidingTextWindow.Reset(30);
+
+            Assert.AreEqual(5, slidingTextWindow.Offset); 
+        }
+
+        [Test]
+        public void Reset_WithPositionNotInWindow_MovesWindow()
+        {
+            var sourceText = SourceText.From("abcdefghijklmnopqrstuvwyx0123456789");
+            var slidingTextWindow = new SlidingTextWindow(sourceText);
+
+            slidingTextWindow.Reset(25);
+
+            Assert.AreEqual(0, slidingTextWindow.Offset);
+            Assert.AreEqual(25, slidingTextWindow.Position);
         }
     }
 }

--- a/SlothCodeAnalysis/Text/SlidingTextWindow.cs
+++ b/SlothCodeAnalysis/Text/SlidingTextWindow.cs
@@ -2,7 +2,13 @@
 
 namespace SlothCodeAnalysis.Text
 {
-    // A sliding buffer over the SourceText of a file for the lexer.
+    /// <summary>
+    /// A sliding window over the SourceText of a file for the lexer.
+    /// The window will grow until the Reset method is called which will reset the window to the given position with the default window size
+    ///
+    ///
+    /// TODO: ideally need to use an object pool of char arrays rather than have this always allocate new char arrays
+    /// </summary>
     public sealed class SlidingTextWindow
     {
         private readonly SourceText _text;
@@ -23,6 +29,12 @@ namespace SlothCodeAnalysis.Text
             _basis = 0;
             _offset = 0;
             _textEnd = text.Length;
+
+            // Populate window
+            int amountToRead = Math.Min(_textEnd - _characterWindowCount, _characterWindow.Length);
+            _characterWindowCount = _characterWindow.Length;
+            _text.CopyTo(0, _characterWindow, 0, amountToRead);
+            _characterWindowCount = amountToRead;
         }
 
         public SourceText Text


### PR DESCRIPTION
Fix bug in SlidingTextWindow constructor as actual population of the text window wasn't happening till PeekChar/NextChar was called - so technically possible to get an error if AdvanceChar is called first to move beyond the end of the text window. Note that the lexer will always call PeekChar/NextChar initially prior to calling AdvanceChar so seems reasonable to pre-populate the window in the constructor